### PR TITLE
Enable path filtering for README.md in GitHub Pages deployment workflow

### DIFF
--- a/.github/workflows/gh-page.yml
+++ b/.github/workflows/gh-page.yml
@@ -2,11 +2,12 @@ name: Deploy GitHub Pages
 
 on:
   push:
-    # paths:
-    #   - 'README.md'
+    paths:
+      - 'README.md'
+
 permissions:
   contents: write
-  
+
 jobs:
   deploy:
     runs-on: ubuntu-latest
@@ -17,7 +18,7 @@ jobs:
 
     - name: Deploy to GitHub Pages
       uses: peaceiris/actions-gh-pages@v3
-      # if: ${{ github.ref == 'refs/heads/main' }}
+      if: ${{ github.ref == 'refs/heads/main' }}
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}
         publish_dir: .

--- a/.github/workflows/gh-page.yml
+++ b/.github/workflows/gh-page.yml
@@ -2,8 +2,8 @@ name: Deploy GitHub Pages
 
 on:
   push:
-    paths:
-      - 'README.md'
+    # paths:
+    #   - 'README.md'
 
 permissions:
   contents: write
@@ -16,9 +16,14 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v4
 
+    - name: Set jeckyll config
+      run: |
+        echo "theme: jekyll-theme-cayman" > _config.yml
+        echo "show_downloads: true" >> _config.yml
+        
     - name: Deploy to GitHub Pages
       uses: peaceiris/actions-gh-pages@v3
-      if: ${{ github.ref == 'refs/heads/main' }}
+      # if: ${{ github.ref == 'refs/heads/main' }}
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}
         publish_dir: .

--- a/.github/workflows/gh-page.yml
+++ b/.github/workflows/gh-page.yml
@@ -2,14 +2,15 @@ name: Deploy GitHub Pages
 
 on:
   push:
-    # paths:
-    #   - 'README.md'
+    paths:
+      - 'README.md'
 
 permissions:
   contents: write
 
 jobs:
   deploy:
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
 
     steps:
@@ -23,7 +24,6 @@ jobs:
         
     - name: Deploy to GitHub Pages
       uses: peaceiris/actions-gh-pages@v3
-      # if: ${{ github.ref == 'refs/heads/main' }}
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}
         publish_dir: .

--- a/.github/workflows/gh-page.yml
+++ b/.github/workflows/gh-page.yml
@@ -2,8 +2,11 @@ name: Deploy GitHub Pages
 
 on:
   push:
-    paths:
-      - 'README.md'
+    # paths:
+    #   - 'README.md'
+permissions:
+  contents: write
+  
 jobs:
   deploy:
     runs-on: ubuntu-latest
@@ -14,7 +17,7 @@ jobs:
 
     - name: Deploy to GitHub Pages
       uses: peaceiris/actions-gh-pages@v3
-      if: ${{ github.ref == 'refs/heads/main' }}
+      # if: ${{ github.ref == 'refs/heads/main' }}
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}
         publish_dir: .

--- a/.github/workflows/gh-page.yml
+++ b/.github/workflows/gh-page.yml
@@ -19,7 +19,7 @@ jobs:
     - name: Set jeckyll config
       run: |
         echo "theme: jekyll-theme-cayman" > _config.yml
-        echo "show_downloads: true" >> _config.yml
+        echo "show_downloads: false" >> _config.yml
         
     - name: Deploy to GitHub Pages
       uses: peaceiris/actions-gh-pages@v3


### PR DESCRIPTION
Enhance the GitHub Pages deployment workflow by enabling path filtering specifically for the README.md file and updating the configuration for Jekyll.