### PR TITLE
Add Snell Server Docker support

### DIFF
--- a/.github/workflows/dispatch-choice.yml
+++ b/.github/workflows/dispatch-choice.yml
@@ -9,6 +9,7 @@ on:
         type: choice
         options:
           - nginx
+          - snell-server
           - abracadabra-web
           - libreoffice-server
           - y-webrtc-signaling
@@ -34,6 +35,16 @@ permissions:
   packages: write
 
 jobs:
+  snell_server_release:
+    if: ${{ github.event.inputs.choice_service == 'snell-server' }}
+    uses: ./.github/workflows/release.yml
+    with:
+      build_context: './Docker/snell-server'
+      docker_image_name: snell-server
+      docker_tag: ${{ github.event.inputs.docker_tag }}
+      build_args: ${{ github.event.inputs.build_args }}
+      build_platforms: ${{ github.event.inputs.build_platforms || 'linux/amd64,linux/arm64,linux/arm/v7,linux/arm/v8,linux/386' }}
+    secrets: inherit
   nginx_release:
     if: ${{ github.event.inputs.choice_service == 'nginx' }}
     uses: ./.github/workflows/release.yml

--- a/.github/workflows/dispatch-choice.yml
+++ b/.github/workflows/dispatch-choice.yml
@@ -43,7 +43,7 @@ jobs:
       docker_image_name: snell-server
       docker_tag: ${{ github.event.inputs.docker_tag }}
       build_args: ${{ github.event.inputs.build_args }}
-      build_platforms: ${{ github.event.inputs.build_platforms || 'linux/amd64,linux/arm64,linux/arm/v7,linux/arm/v8,linux/386' }}
+      build_platforms: ${{ github.event.inputs.build_platforms || 'linux/amd64,linux/arm64,linux/arm/v7,linux/386' }}
     secrets: inherit
   nginx_release:
     if: ${{ github.event.inputs.choice_service == 'nginx' }}

--- a/Docker/snell-server/Dockerfile
+++ b/Docker/snell-server/Dockerfile
@@ -1,0 +1,51 @@
+FROM --platform=$BUILDPLATFORM debian:sid-slim AS builder
+
+ARG VERSION=4.1.1
+ARG TARGETPLATFORM
+
+WORKDIR /opt/snell-server
+
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends wget unzip && \
+    case "${TARGETPLATFORM}" in \
+        "linux/amd64") ARCH="amd64" ;; \
+        "linux/arm64") ARCH="aarch64" ;; \
+        "linux/arm/v7") ARCH="armv7l" ;; \
+        "linux/arm/v8") ARCH="arm64" ;; \
+        "linux/386") ARCH="i386" ;; \
+        *) echo "unsupported platform: ${TARGETPLATFORM}"; exit 1 ;; \
+    esac && \
+    wget --no-check-certificate -O snell.zip "https://dl.nssurge.com/snell/snell-server-v${VERSION}-linux-${ARCH}.zip" && \
+    unzip snell.zip && \
+    rm -f snell.zip && \
+    apt-get purge -y --auto-remove wget unzip && \
+    rm -rf /var/lib/apt/lists/*
+
+FROM debian:stable-slim
+
+ARG BUILD_DATE
+ARG VERSION=4.1.1
+
+LABEL org.label-schema.name="snell-server" \
+      org.label-schema.description="snell server is a lean encrypted proxy protocol." \
+      org.label-schema.version="${VERSION}" \
+      org.label-schema.build-date="${BUILD_DATE}" \
+      org.label-schema.vendor="Leon<silenceace@gmail.com>" \
+      org.label-schema.url="https://github.com/funnyzak/docker-release"
+
+WORKDIR /opt/snell-server
+
+COPY --from=builder /opt/snell-server/snell-server .
+COPY entrypoint.sh .
+
+RUN chmod +x snell-server entrypoint.sh
+
+ENV LANG=C.UTF-8 \
+    TZ=Asia/Shanghai \
+    PORT=6180 \
+    IPV6=false \
+    PSK=
+
+EXPOSE ${PORT}/tcp
+
+ENTRYPOINT ["/opt/snell-server/entrypoint.sh"]

--- a/Docker/snell-server/Dockerfile
+++ b/Docker/snell-server/Dockerfile
@@ -10,6 +10,7 @@ RUN apt-get update && \
     case "${TARGETPLATFORM}" in \
         "linux/amd64") ARCH="amd64" ;; \
         "linux/arm64") ARCH="aarch64" ;; \
+        "linux/arm64/v8") ARCH="aarch64" ;; \
         "linux/arm/v7") ARCH="armv7l" ;; \
         "linux/386") ARCH="i386" ;; \
         *) echo "unsupported platform: ${TARGETPLATFORM}"; exit 1 ;; \

--- a/Docker/snell-server/Dockerfile
+++ b/Docker/snell-server/Dockerfile
@@ -10,7 +10,6 @@ RUN apt-get update && \
     case "${TARGETPLATFORM}" in \
         "linux/amd64") ARCH="amd64" ;; \
         "linux/arm64") ARCH="aarch64" ;; \
-        "linux/arm64/v8") ARCH="aarch64" ;; \
         "linux/arm/v7") ARCH="armv7l" ;; \
         "linux/386") ARCH="i386" ;; \
         *) echo "unsupported platform: ${TARGETPLATFORM}"; exit 1 ;; \

--- a/Docker/snell-server/Dockerfile
+++ b/Docker/snell-server/Dockerfile
@@ -41,6 +41,7 @@ COPY entrypoint.sh .
 RUN chmod +x snell-server entrypoint.sh
 
 ENV LANG=C.UTF-8 \
+    VERSION=${VERSION} \
     TZ=Asia/Shanghai \
     PORT=6180 \
     IPV6=false \

--- a/Docker/snell-server/Dockerfile
+++ b/Docker/snell-server/Dockerfile
@@ -11,7 +11,6 @@ RUN apt-get update && \
         "linux/amd64") ARCH="amd64" ;; \
         "linux/arm64") ARCH="aarch64" ;; \
         "linux/arm/v7") ARCH="armv7l" ;; \
-        "linux/arm/v8") ARCH="arm64" ;; \
         "linux/386") ARCH="i386" ;; \
         *) echo "unsupported platform: ${TARGETPLATFORM}"; exit 1 ;; \
     esac && \

--- a/Docker/snell-server/README.md
+++ b/Docker/snell-server/README.md
@@ -1,0 +1,68 @@
+# Snell Server
+
+[![Image Size](https://img.shields.io/docker/image-size/funnyzak/snell-server)](https://hub.docker.com/r/funnyzak/snell-server/)
+[![Docker Stars](https://img.shields.io/docker/stars/funnyzak/snell-server.svg?style=flat-square)](https://hub.docker.com/r/funnyzak/snell-server/)
+[![Docker Pulls](https://img.shields.io/docker/pulls/funnyzak/snell-server.svg?style=flat-square)](https://hub.docker.com/r/funnyzak/snell-server/)
+[![Docker Tags](https://img.shields.io/docker/v/funnyzak/snell-server?sort=semver&style=flat-square)](https://hub.docker.com/r/funnyzak/snell-server/)
+
+Snell Server is a lean encrypted proxy protocol. It is designed to be simple, lightweight.
+
+This image is build from the latest source code of [Snell Server](https://manual.nssurge.com/others/snell.html). It supports `linux/amd64`, `linux/arm64`, `linux/arm/v7`, `linux/386` architecture. 
+
+**Notice**: Need to use with Surge iOS or Surge Mac, both of them support Snell protocol. The latest surge-server version is v4, which is not compatible with the previous versions like before. Please upgrade both the client (Surge iOS & Surge Mac) and the server binary.
+
+## Docker Pull
+
+```bash
+docker pull funnyzak/snell-server
+# GHCR
+docker pull ghcr.io/funnyzak/snell-server
+# Aliyun
+docker pull registry.cn-beijing.aliyuncs.com/funnyzak/snell-server
+```
+
+## Docker Run
+
+Your can run this image with the following command:
+
+```bash
+# One line command
+docker run -d --name snell-server --restart always -p 12303:6180 -e PSK="5G0H4qdf32mEZx32t" funnyzak/snell-server
+
+# Or with environment variables
+docker run -d --name snell-server --restart always \
+  -e PSK="5G0H4qdf32mEZx32t" \
+  -e TZ="Asia/Shanghai" \
+  -e IPV6="false" \
+  -e PORT=6180 \
+  -p 12303:6180 funnyzak/snell-server:latest
+
+# Echo config file
+docker exec -it snell-server cat /etc/snell-server.conf
+```
+
+Or you can use docker-compose to run this image:
+
+```yaml
+version: '3'
+services:
+  snell:
+    image: funnyzak/snell-server
+    container_name: snell-server
+    environment:
+      PSK: 5G0H4qdf32mEZx32t
+      TZ: Asia/Shanghai
+      IPV6: false
+      PORT: 6180
+    restart: always
+    ports:
+      - 12303:6180
+```
+
+## Reference
+
+- [Snell Server](https://manual.nssurge.com/others/snell.html)
+
+## License
+
+[MIT](LICENSE)

--- a/Docker/snell-server/README.md
+++ b/Docker/snell-server/README.md
@@ -9,7 +9,7 @@ Snell Server is a lean encrypted proxy protocol. It is designed to be simple, li
 
 This image is build from the latest source code of [Snell Server](https://manual.nssurge.com/others/snell.html). It supports `linux/amd64`, `linux/arm64`, `linux/arm/v7`, `linux/386` architecture. 
 
-**Notice**: Need to use with Surge iOS or Surge Mac, both of them support Snell protocol. The latest surge-server version is v4, which is not compatible with the previous versions like before. Please upgrade both the client (Surge iOS & Surge Mac) and the server binary.
+> **Notice**: Need to use with Surge iOS or Surge Mac, both of them support Snell protocol. The latest surge-server version is v4, which is not compatible with the previous versions like before. Please upgrade both the client (Surge iOS & Surge Mac) and the server binary.
 
 ## Docker Pull
 
@@ -62,7 +62,3 @@ services:
 ## Reference
 
 - [Snell Server](https://manual.nssurge.com/others/snell.html)
-
-## License
-
-[MIT](LICENSE)

--- a/Docker/snell-server/entrypoint.sh
+++ b/Docker/snell-server/entrypoint.sh
@@ -1,0 +1,31 @@
+#!/bin/sh
+
+BIN="/opt/snell-server/snell-server"
+CONF="/etc/snell-server.conf"
+
+run() {
+  if [ ! -f ${CONF} ]; then
+    PSK=${PSK:-$(tr -dc A-Za-z0-9 </dev/urandom | head -c 31)}
+    PORT=${PORT:-6180}
+    IPV6=${IPV6:-false}
+
+    echo "Using PSK: ${PSK}"
+    echo "Using port: ${PORT}"
+    echo "Using ipv6: ${IPV6}"
+
+    echo "Generating new config..."
+    cat << EOF > ${CONF}
+[snell-server]
+listen = 0.0.0.0:${PORT}
+psk = ${PSK}
+ipv6 = ${IPV6}
+EOF
+  fi
+  echo -e "Starting snell-server...\n"
+  echo "Config:"
+  cat ${CONF}
+  echo ""
+  ${BIN} -c ${CONF}
+}
+
+run

--- a/Docker/snell-server/entrypoint.sh
+++ b/Docker/snell-server/entrypoint.sh
@@ -1,9 +1,16 @@
-#!/bin/sh
+#!/bin/bash
 
 BIN="/opt/snell-server/snell-server"
 CONF="/etc/snell-server.conf"
 
 run() {
+  # 打印作者和版本信息
+  echo -e "Snell-Server\n"
+  echo -e "Image: https://hub.docker.com/r/funnyzak/snell-server"
+  echo -e "GitHub: https://github.com/funnyzak/docker-release\n"
+
+  echo -e "Starting snell-server ${VERSION}...\n"
+
   if [ ! -f ${CONF} ]; then
     PSK=${PSK:-$(tr -dc A-Za-z0-9 </dev/urandom | head -c 31)}
     PORT=${PORT:-6180}
@@ -21,10 +28,11 @@ psk = ${PSK}
 ipv6 = ${IPV6}
 EOF
   fi
-  echo -e "Starting snell-server...\n"
+
   echo "Config:"
   cat ${CONF}
   echo ""
+
   ${BIN} -c ${CONF}
 }
 

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Images are provided with the `latest` and `nightly` tags (if available). For oth
 Current images are as follows:
 
 - `funnyzak/nginx:latest`: The Nginx image ([Hub](https://hub.docker.com/r/funnyzak/nginx)).
+- `funnyzak/snell-server:latest`: The Snell-Server image ([Hub](https://hub.docker.com/r/funnyzak/snell-server)).
 - `funnyzak/y-webrtc-signaling:latest`: The y-webrtc-signaling signaling server image ([Hub](https://hub.docker.com/r/funnyzak/y-webrtc-signaling)).
 - `funnyzak/abracadabra-web:latest`: The Abracadabra_demo magic demo image ([Hub](https://hub.docker.com/r/funnyzak/abracadabra-web)).
 - `funnyzak/libreoffice-server:latest`: The LibreOffice-Server image ([Hub](https://hub.docker.com/r/funnyzak/libreoffice-server)).
@@ -26,6 +27,7 @@ Current images are as follows:
 Images build directory is located at ./Docker. You can also download the directory to build the images yourself.
 
 - `./Docker/nginx`: Build the [Nginx](https://nginx.org) service image.
+- `./Docker/snell-server`: Build the [Snell-Server](https://manual.nssurge.com/others/snell.htm) service image.
 - `./Docker/y-webrtc-signaling`: Build the [y-webrtc-signaling](https://github.com/lobehub/y-webrtc-signaling) service image.
 - `./Docker/abracadabra-web`: Build the [Abracadabra_demo](https://github.com/SheepChef/Abracadabra_demo) service image.
 - `./Docker/libreoffice-server`: Build the [LibreOffice-Server](https://github.com/funnyzak/libreoffice-server) service image.
@@ -93,6 +95,70 @@ services:
 For more information, please check [Nginx](https://github.com/funnyzak/docker-release/tree/main/Docker/nginx/README.md).
 
 ---
+
+### Snell-Server
+
+[![Image Size](https://img.shields.io/docker/image-size/funnyzak/snell-server)](https://hub.docker.com/r/funnyzak/snell-server/)
+[![Docker Stars](https://img.shields.io/docker/stars/funnyzak/snell-server.svg?style=flat-square)](https://hub.docker.com/r/funnyzak/snell-server/)
+[![Docker Pulls](https://img.shields.io/docker/pulls/funnyzak/snell-server.svg?style=flat-square)](https://hub.docker.com/r/funnyzak/snell-server/)
+[![Docker Tags](https://img.shields.io/docker/v/funnyzak/snell-server?sort=semver&style=flat-square)](https://hub.docker.com/r/funnyzak/snell-server/)
+
+Snell Server is a lean encrypted proxy protocol. It is designed to be simple, lightweight.
+
+This image is build from the latest source code of [Snell Server](https://manual.nssurge.com/others/snell.html). It supports `linux/amd64`, `linux/arm64`, `linux/arm/v7`, `linux/386` architecture. 
+
+> **Notice**: Need to use with Surge iOS or Surge Mac, both of them support Snell protocol. The latest surge-server version is v4, which is not compatible with the previous versions like before. Please upgrade both the client (Surge iOS & Surge Mac) and the server binary.
+
+**Pulling the Image**:
+
+<details>
+
+```bash
+docker pull funnyzak/snell-server
+# GHCR
+docker pull ghcr.io/funnyzak/snell-server
+# Aliyun
+docker pull registry.cn-beijing.aliyuncs.com/funnyzak/snell-server
+```
+
+</details>
+
+**Deployment**:
+
+<details>
+
+**Docker Deployment**:
+```bash
+docker run -d --name snell-server --restart always -p 12303:6180 -e PSK="5G0H4qdf32mEZx32t" funnyzak/snell-server
+```
+
+**Docker Compose Deployment**:
+```yaml
+version: '3'
+
+services:
+  snell:
+    image: funnyzak/snell-server
+    container_name: snell-server
+    environment:
+      PSK: 5G0H4qdf32mEZx32t
+      TZ: Asia/Shanghai
+      IPV6: false
+      PORT: 6180
+    restart: always
+    ports:
+      - 12303:6180
+```
+
+**Echo config file**:
+```bash
+docker exec -it snell-server cat /etc/snell-server.conf
+```
+
+</details>
+
+For more information, please check [Snell-Server](https://github.com/funnyzak/docker-release/tree/main/Docker/snell-server/README.md).
+
 
 ### y-webrtc-signaling
 

--- a/README.md
+++ b/README.md
@@ -159,6 +159,7 @@ docker exec -it snell-server cat /etc/snell-server.conf
 
 For more information, please check [Snell-Server](https://github.com/funnyzak/docker-release/tree/main/Docker/snell-server/README.md).
 
+---
 
 ### y-webrtc-signaling
 

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Images build directory is located at ./Docker. You can also download the directo
 
 ## Services
 
-### nginx
+### Nginx
 
 [![Image Size](https://img.shields.io/docker/image-size/funnyzak/nginx/latest)](https://hub.docker.com/r/funnyzak/nginx/tags)
 [![Docker Pulls](https://img.shields.io/docker/pulls/funnyzak/nginx)](https://hub.docker.com/r/funnyzak/nginx)
@@ -161,7 +161,7 @@ For more information, please check [Snell-Server](https://github.com/funnyzak/do
 
 ---
 
-### y-webrtc-signaling
+### Y-WebRTC Signaling
 
 [![Docker Image Size](https://img.shields.io/docker/image-size/funnyzak/y-webrtc-signaling/latest)](https://hub.docker.com/r/funnyzak/y-webrtc-signaling/tags)
 ![Docker Pulls](https://img.shields.io/docker/pulls/funnyzak/y-webrtc-signaling)
@@ -383,7 +383,7 @@ For more information, please check [Request-Hub](https://github.com/funnyzak/doc
 
 ---
 
-### Canal
+### Alibaba Canal
 
 Canal is a component for incremental subscription and consumption of binlogs in Alibaba's MySQL database.
 

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ A nginx docker image with secure configurations and some useful modules, such as
 
 Build with the  `linux/arm64`, `linux/386`, `linux/amd64`, `linux/arm/v6`, `linux/arm/v7`, `linux/arm64/v8` architectures.
 
-**Pulling the Image**:
+**Pull**:
 
 <details>
 
@@ -109,7 +109,7 @@ This image is build from the latest source code of [Snell Server](https://manual
 
 > **Notice**: Need to use with Surge iOS or Surge Mac, both of them support Snell protocol. The latest surge-server version is v4, which is not compatible with the previous versions like before. Please upgrade both the client (Surge iOS & Surge Mac) and the server binary.
 
-**Pulling the Image**:
+**Pull**:
 
 <details>
 
@@ -171,7 +171,7 @@ Y-WebRTC is a WebRTC signaling server. More information can be found at [y-webrt
 
 This image is built with the `linux/amd64`, `linux/arm64`, `linux/arm/v7`, `linux/arm64/v8`, `linux/ppc64le`, `linux/s390x` architectures.
 
-**Pulling the Image**:
+**Pull**:
 <details>
 
 ```bash
@@ -219,7 +219,7 @@ Abracadabra (魔曰) is an instant text encryption/de-sensitization tool, which 
 
 This image is built with the `linux/amd64`, `linux/arm64`, `linux/arm/v7`, `linux/arm64/v8`, `inux/ppc64le`, `linux/s390x` architectures.
 
-**Pulling the Image**:
+**Pull**:
 <details>
 
 ```bash
@@ -278,7 +278,7 @@ LibreOffice Service service for editing documents online and converting Word to 
 
 This image is built with the `linux/amd64`, `linux/arm64` architectures.
 
-**Pulling the Image**:
+**Pull**:
 <details>
 
 ```bash
@@ -330,7 +330,7 @@ For more information, please check [LibreOffice-Server](https://github.com/funny
 
 [RequestHub](https://github.com/kyledayton/requesthub) is used to receive, record, and proxy HTTP requests. This image supports `linux/386`, `linux/amd64`, `linux/arm/v6`, `linux/arm/v7`, `linux/arm64/v8`, `linux/s390x`.
 
-**Pulling the Image**:
+**Pull**:
 <details>
 
 ```bash
@@ -405,7 +405,7 @@ Currently, three images are provided:
 
 All are installed under the `/opt/canal` directory. For, the installation directory of the `canal-adapter` service is under `/opt/canal/canal-adapter`.
 
-**Pulling the Images**:
+**Pulls**:
 
 <details>
 


### PR DESCRIPTION
Introduce Docker support for Snell Server, including version information and an updated entrypoint script. Remove unsupported build platform from configurations to streamline the build process.