### PR TITLE
Update Dockerfile to use Eclipse Temurin base image

### DIFF
--- a/Docker/openjdk/Dockerfile
+++ b/Docker/openjdk/Dockerfile
@@ -1,13 +1,13 @@
-ARG VERSION=11
+ARG VERSION=11-jre
 
-FROM openjdk:${VERSION}
+FROM eclipse-temurin:${VERSION}
 
 ARG BUILD_DATE
 ARG VERSION
 ARG VCS_REF
 
-LABEL org.label-schema.name="java" \
-      org.label-schema.description="java" \
+LABEL org.label-schema.name="OpenJDK" \
+      org.label-schema.description="Official Images for OpenJDK binaries built by Eclipse Temurin." \
       org.label-schema.version="${VERSION}" \
       org.label-schema.vcs-ref="${VCS_REF}" \
       org.label-schema.build-date="${BUILD_DATE}" \


### PR DESCRIPTION
Switch the base image in the Dockerfile to Eclipse Temurin and adjust the version argument accordingly.