### PR TITLE
Update Docker cron image and documentation

### DIFF
--- a/.github/workflows/check-offical-release.yml
+++ b/.github/workflows/check-offical-release.yml
@@ -96,7 +96,7 @@ jobs:
       - name: Check if new version exists on docker hub
         id: check-docker-hub
         run: |
-          if [ ${{ steps.get-latest-release.outputs.new_release_version }} == 'no-tags' ]; then
+          if [ "${{ steps.get-latest-release.outputs.new_release_version }}" = "no-tags" ] || [ "${{ steps.get-latest-release.outputs.new_release_version }}" = "null" ]; then
             echo "Can't get the new Offical Release version"
             echo "is_new_release_version=false" >> $GITHUB_OUTPUT
           elif curl -s "https://hub.docker.com/v2/repositories/funnyzak/${{ github.event.inputs.image_name || inputs.image_name }}/tags/${{ steps.get-latest-release.outputs.new_release_version }}" | grep -q 'not found'; then

--- a/.github/workflows/dispatch-choice.yml
+++ b/.github/workflows/dispatch-choice.yml
@@ -140,7 +140,7 @@ jobs:
       docker_image_name: cron
       docker_tags: ${{ github.event.inputs.docker_tags }}
       build_args: ${{ github.event.inputs.build_args }}
-      build_platforms: ${{ github.event.inputs.build_platforms || 'linux/386,linux/amd64,linux/arm64,linux/arm/v6,linux/arm/v7,linux/arm64/v8,linux/ppc64le,linux/riscv64,linux/s390x' }}
+      build_platforms: ${{ github.event.inputs.build_platforms || 'linux/386,linux/amd64,linux/arm64,linux/arm/v6,linux/arm/v7,linux/arm64/v8,linux/ppc64le,linux/riscv64' }}
     secrets: inherit
     
   one_api_release:

--- a/Docker/certimate/README.md
+++ b/Docker/certimate/README.md
@@ -27,4 +27,28 @@ docker pull registry.cn-beijing.aliyuncs.com/funnyzak/certimate:latest
 docker run -d --name certimate_server -p 8090:8090 -v $(pwd)/data:/app/pb_data --restart unless-stopped funnyzak/certimate:latest
 ```
 
+### Docker Compose Deployment
+
+```yaml
+version: '3.7'
+services:
+  certimate:
+    image: funnyzak/certimate:latest
+    container_name: certimate_server
+    ports:
+      - "8090:8090"
+    volumes:
+      - ./data:/app/pb_data
+    restart: unless-stopped
+```
+
+
+After completing the installation steps above, you can access the Certimate admin panel at:
+http://127.0.0.1:8090
+
+Default credentials:
+- Username: admin@certimate.fun
+- Password: 1234567890
+
+
 More information can be found at [certimate](https://github.com/usual2970/certimate).

--- a/Docker/cron/Dockerfile
+++ b/Docker/cron/Dockerfile
@@ -7,7 +7,7 @@ ARG VERSION
 ENV TZ=Asia/Shanghai \
     LC_ALL=C.UTF-8 \
     LANG=C.UTF-8 \
-    INSTALL_PACKAGES="dcron ca-certificates curl tar tzdata bash zip unzip rsync"
+    INSTALL_PACKAGES="dcron ca-certificates curl tar tzdata bash zip unzip rsync rclone"
 
 LABEL org.label-schema.name="Alpine CRON" \
       org.label-schema.description="CRON is a lightweight Docker image containing Cron, based on Alpine Linux. Includes some useful tools for cron jobs. Such as ${INSTALL_PACKAGES}." \

--- a/Docker/cron/Dockerfile
+++ b/Docker/cron/Dockerfile
@@ -7,7 +7,7 @@ ARG VERSION
 ENV TZ=Asia/Shanghai \
     LC_ALL=C.UTF-8 \
     LANG=C.UTF-8 \
-    INSTALL_PACKAGES="dcron ca-certificates curl tar tzdata bash zip unzip rsync rclone"
+    INSTALL_PACKAGES="dcron ca-certificates curl tar tzdata bash zip unzip rsync"
 
 LABEL org.label-schema.name="Alpine CRON" \
       org.label-schema.description="CRON is a lightweight Docker image containing Cron, based on Alpine Linux. Includes some useful tools for cron jobs. Such as ${INSTALL_PACKAGES}." \

--- a/Docker/cron/README.md
+++ b/Docker/cron/README.md
@@ -102,7 +102,6 @@ services:
     environment:
       - TZ=Asia/Shanghai
       - LANG=C.UTF-8
-      - CRON_TAIL=1
       - CRON_STRINGS=* * * * * /scripts/echo.sh >> /var/log/cron/cron.log 2>&1
     restart: on-failure
     volumes:

--- a/Docker/cron/README.md
+++ b/Docker/cron/README.md
@@ -7,7 +7,7 @@
 
 cron is a lightweight service that runs in the background and executes scheduled tasks. It builds on the official `alpine` image and includes `dcron` as the cron service. The image is available for multiple architectures, including `linux/386`, `linux/amd64`, `linux/arm/v6`, `linux/arm/v7`, `linux/arm64/v8`, `linux/ppc64le`, `linux/riscv64`, `linux/s390x`.
 
-Installed packages: `dcron`, `ca-certificates`, `curl`, `tar`, `tzdata`, `bash`, `zip`, `unzip`, `rsync`, `rclone`.
+Installed packages: `dcron`, `ca-certificates`, `curl`, `tar`, `tzdata`, `bash`, `zip`, `unzip`, `rsync`.
 
 ## Pull the Image
 

--- a/Docker/cron/README.md
+++ b/Docker/cron/README.md
@@ -7,7 +7,7 @@
 
 cron is a lightweight service that runs in the background and executes scheduled tasks. It builds on the official `alpine` image and includes `dcron` as the cron service. The image is available for multiple architectures, including `linux/386`, `linux/amd64`, `linux/arm/v6`, `linux/arm/v7`, `linux/arm64/v8`, `linux/ppc64le`, `linux/riscv64`, `linux/s390x`.
 
-Installed packages: `dcron`, `ca-certificates`, `curl`, `tar`, `tzdata`, `bash`, `zip`, `unzip`, `rsync`.
+Installed packages: `dcron`, `ca-certificates`, `curl`, `tar`, `tzdata`, `bash`, `zip`, `unzip`, `rsync`, `rclone`.
 
 ## Pull the Image
 


### PR DESCRIPTION
Remove unnecessary environment variable from the Docker cron README, add rclone to the installed packages, and enhance the Certimate README with Docker Compose deployment instructions. Additionally, handle an extra null case in the GitHub Actions workflow for version checks.